### PR TITLE
Fixes typo in GitHub account name.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,7 +37,7 @@ owner:
   disqus-shortname:
   twitter: #username
   facebook: #username
-  github: rubyherzelein
+  github: rubyherzlein
   stackexchange: #http://stackoverflow.com/users/123456/username
   linkedin: #username
   instagram: #username


### PR DESCRIPTION
You also have to change the GitHub account name in the home page URL of https://twitter.com/RubyherzleinRG like this.